### PR TITLE
Read deployment params from repo

### DIFF
--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -6,17 +6,55 @@ image_resource:
   source:
     repository: gempesaw/curl-jq
 
+# directories this task can read from
 inputs:
 - name: webapp-source
 
+# exported directories, where output files can be shared with other tasks
 outputs:
 - name: deploy-params
 
+# These params are made available as environment variables
+# The values are passed by the invoking pipeline
 params:
   IPS_DOM1:
   IPS_QUANTUM:
   IPS_102PF_WIFI:
 
+# jq script does the following:
+#
+# * sh -ec
+#   run (c)ommand and (e)xit on errors
+#
+# * < webapp-source/deploy.json
+#   reads JSON from input directory `webapp-source`. This is an object with the
+#   following keys:
+#     enable_authentication - optional - true/false
+#     allowed_ip_ranges - optional - array of names of ip ranges
+#
+# * --argjson ip "{...}"
+#   sets the variable `ip` to the JSON object mapping names to ip ranges
+#
+# * -r
+#   output raw string, not JSON texts
+#
+# * (.enable_authentication // true)
+#   gets the value of the enable_authentication key, or `true` if missing
+#
+# * (.allowed_ip_ranges // ["DOM1"])
+#   gets the array of ip range names, or a default array containing "DOM1"
+#
+# * | map($ip[.])
+#   maps the array of ip range names to their corresponding value in `ip`
+#
+# * | join(",")
+#   concatenates the ip ranges into a comma separated string
+#
+# * | gsub(...)
+#   escapes all commas and periods with "\\"
+#
+# * > deploy-params/overrides.yaml
+#   writes JSON output to exported file
 run:
   path: sh
   args:

--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -16,7 +16,6 @@ params:
   IPS_DOM1:
   IPS_QUANTUM:
   IPS_102PF_WIFI:
-  IPS_CLIVE_HOUSE:
 
 run:
   path: sh
@@ -25,7 +24,6 @@ run:
   - |
     jq --argjson ip "{
       \"102PF Wifi\": \"$IPS_102PF_WIFI\",
-      \"Clive House Wifi\": \"$IPS_CLIVE_HOUSE_WIFI\",
       \"DOM1\": \"$IPS_DOM1\",
       \"QUANTUM\": \"$IPS_QUANTUM\"
     }" -r '{

--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -1,0 +1,36 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gempesaw/curl-jq
+
+inputs:
+- name: webapp-source
+
+outputs:
+- name: deploy-params
+
+params:
+  IPS_DOM1:
+  IPS_QUANTUM:
+  IPS_102PF_WIFI:
+  IPS_CLIVE_HOUSE:
+
+run:
+  path: sh
+  args:
+  - -ec
+  - |
+    jq --argjson ip "{
+      \"102PF Wifi\": \"$IPS_102PF_WIFI\",
+      \"Clive House Wifi\": \"$IPS_CLIVE_HOUSE_WIFI\",
+      \"DOM1\": \"$IPS_DOM1\",
+      \"QUANTUM\": \"$IPS_QUANTUM\"
+    }" -r '{
+      AuthProxy: {
+        AuthenticationRequired: (.enable_authentication // true),
+        IPRanges: (.allowed_ip_ranges // ["102PF Wifi"]) | map($ip[.]) | join(",") | gsub("(?<x>[,.])"; "\\\(.x)")
+      }
+    }' < webapp-source/deploy.json > deploy-params/overrides.yaml

--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -31,6 +31,6 @@ run:
     }" -r '{
       AuthProxy: {
         AuthenticationRequired: (.enable_authentication // true),
-        IPRanges: (.allowed_ip_ranges // ["102PF Wifi"]) | map($ip[.]) | join(",") | gsub("(?<x>[,.])"; "\\\(.x)")
+        IPRanges: (.allowed_ip_ranges // ["DOM1"]) | map($ip[.]) | join(",") | gsub("(?<x>[,.])"; "\\\(.x)")
       }
     }' < webapp-source/deploy.json > deploy-params/overrides.yaml


### PR DESCRIPTION
* Adds a Concourse task YAML definition, which can be imported by a pipeline to convert a `deploy.json` file in the `webapp-source` input directory to a `overrides.yaml` file which is compatible with the `webapp` Helm chart
* This allows users to add parameters to the deployments of their webapps, by including `deploy.json` in the root directory of their github repo, with the following (example) contents:
```json
{
  "enable_authentication": true,

  "allowed_ip_ranges": [
    "102PF Wifi",
    "DOM1",
    "QUANTUM"
  ]
}
```
* Default values if omitted are `enable_authentication: true` and `allowed_ip_ranges: ["DOM1"]`