### PR TITLE
Put Iam Role Task

### DIFF
--- a/put-iam-role.yaml
+++ b/put-iam-role.yaml
@@ -1,0 +1,42 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/awscli
+
+inputs:
+  - name: common-tasks
+  - name: source
+
+outputs:
+- name: output
+
+params:
+  AWS_ACCESS_KEY_ID: ((role-putter-access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((role-putter-secret-access-key))
+  AWS_NODES_ROLE_ARN: ((node-arn))
+  APP_NAME: ((app-name))
+
+run:
+  path: sh
+  args:
+  - -ecx
+  - |
+    sed 's@${AWS_NODES_ROLE_ARN}@'$AWS_NODES_ROLE_ARN'@g' ./common-tasks/templates/trust-policy.json.tmpl > ./trust-policy.json
+    export ROLE_NAME=$(cat source/deploy.json | jq -r '.role_name')
+    if [ -f "./source/iam_policy.json" ]; then
+      if aws iam get-role --role-name $ROLE_NAME; then
+        echo "Updating Role ($ROLE_NAME) with Inline Policy:"
+      else
+        echo "Creating Role ($ROLE_NAME) with Inline Policy:"
+        aws iam create-role --role-name $ROLE_NAME --assume-role-policy-document file://./trust-policy.json
+      fi
+      cat ./source/iam_policy.json
+      aws iam put-role-policy --role-name $ROLE_NAME --policy-document file://./source/iam_policy.json --policy-name $APP_NAME
+    else
+      echo "No inline policy found at iam_policy.json, skip creating role."
+    fi
+    echo $ROLE_NAME > output/iam_role_name
+    echo "IAM role name: $ROLE_NAME"

--- a/templates/trust-policy.json.tmpl
+++ b/templates/trust-policy.json.tmpl
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com",
+          "glue.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${AWS_NODES_ROLE_ARN}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}


### PR DESCRIPTION
Create a new common task to create an iam role with a provided inline policy
that can be assumed by the cluster (nodes-role-arn).

The inline policy should be located in at `source/iam/inline_policy.json`, this
is not configurable at the moment.

To use this common task you need to pass through the following variables:

```bash
AWS_ACCESS_KEY_ID: access key id for aws user that can create/edit policies
AWS_SECRET_ACCESS_KEY: access key for above
AWS_NODES_ROLE_ARN: the role that the nodes that can assume this role will have
APP_NAME: a name for the inline_policy
```

The user needs the following policy attached if you're making it manually; we'll
be creating in terraform.

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "iam:GetRole",
                "iam:PutRolePolicy",
                "iam:UpdateAssumeRolePolicy",
                "iam:DeleteRolePolicy",
                "iam:UpdateRoleDescription",
                "iam:CreateRole",
                "iam:AttachRolePolicy",
                "iam:UpdateRole",
                "iam:PutRolePolicy",
                "iam:GetRolePolicy"
            ],
            "Resource": "arn:aws:iam::*:role/*"
        },
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": "iam:ListRoles",
            "Resource": "*"
        }
    ]
}
```