### PR TITLE
Add support to "port" deploy param

### DIFF
--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -64,14 +64,4 @@ run:
       }, output)
     print('Wrote deploy-params/overrides.yaml')
 
-    os.mkdir('deploy-params/auth-proxy')
-
-    with open('deploy-params/auth-proxy/auth-required', 'w') as f:
-      f.write(str(auth_required).lower())
-      print('Wrote deploy-params/auth-proxy/auth-required')
-
-    with open('deploy-params/auth-proxy/ip-ranges', 'w') as f:
-      f.write(','.join(ip_ranges))
-      print('Wrote deploy-params/auth-proxy/ip-ranges')
-
     EOF

--- a/parse-deploy-file.yaml
+++ b/parse-deploy-file.yaml
@@ -49,13 +49,18 @@ run:
       ip_ranges = [lookup['DOM1']]
 
     auth_required = not data.get('disable_authentication', False)
+    webapp_port = data.get('port', 80)
 
+    # The following are input values of the webapp helm chart
     with open('deploy-params/overrides.yaml', 'w') as output:
       json.dump({
         'AuthProxy': {
           'AuthenticationRequired': auth_required,
-          'IPRanges': ','.join(ip_ranges)
-        }
+          'IPRanges': ','.join(ip_ranges),
+        },
+        'WebApp': {
+          'Port': webapp_port,
+        },
       }, output)
     print('Wrote deploy-params/overrides.yaml')
 


### PR DESCRIPTION
Default to `80` for now to avoid breaking compatibility with existing
webapps.

Once we got to a stage were most apps are updated to add the `port`
param to their `deploy.json` and moved to images that don't run
as `root` we can even start to raise exceptions when this param is
less than `1025`.

Part of ticket: https://trello.com/c/x7zhOJ4N/223-run-webapp-as-non-root-not-on-port-80