### PR TITLE
add deploy.json linting support

### DIFF
--- a/validate-deploy-file.yaml
+++ b/validate-deploy-file.yaml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: quay.io/mojanalytics/deployjson
+    tag: latest
+
+# directories this task can read from
+inputs:
+- name: webapp-source
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    yarn start -f ${PWD}/webapp-source/deploy.json


### PR DESCRIPTION
Adds a task to lint deploy.json files: 
can be used in a pipeline: 
```yaml
  - task: lint-deploy
    file: common-tasks/validate-deploy-file.yaml

```