### PR TITLE
Add flake8 config from python black to stop line too long errors

### DIFF
--- a/conf/.flake8
+++ b/conf/.flake8
@@ -2,4 +2,5 @@
 
 # Increase max line length to be the same as python black
 max-line-length = 88
-extend-ignore = E203
+select = C,E,F,W,B,B950
+ignore = E501


### PR DESCRIPTION
This is supposedly the python black flake8 config - https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length