### PR TITLE
Change to use ecr for busybox image

### DIFF
--- a/extract-release-tarball.yaml
+++ b/extract-release-tarball.yaml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: busybox
+    repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/busybox
 
 inputs:
 - name: release


### PR DESCRIPTION
Due to docker rate limiting we want to store images in ECR